### PR TITLE
ci: add Node.js setup for redocly CLI compatibility

### DIFF
--- a/.github/workflows/termite-go.yml
+++ b/.github/workflows/termite-go.yml
@@ -66,6 +66,11 @@ jobs:
       - name: Clone antfly-go (for OpenAPI refs)
         run: git clone --depth 1 https://github.com/antflydb/antfly-go.git ../antfly-go
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -174,6 +179,11 @@ jobs:
 
       - name: Clone antfly-go (for OpenAPI refs)
         run: git clone --depth 1 https://github.com/antflydb/antfly-go.git ../antfly-go
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
from an investigation into why #19 was failing CI

---
## Summary
- Add `setup-node@v4` with Node.js 22 to the CI workflow
- `@redocly/cli@latest` (v2.14.5) now requires Node.js >=20.19.0
- CI runners default to Node 18, causing the `pure-go` test matrix to fail during `make test` -> `build-docs`

## Test plan
- [ ] CI passes on this PR