### PR TITLE
proxy library seams

### DIFF
--- a/pkg/operator/controllers/termitepool_controller.go
+++ b/pkg/operator/controllers/termitepool_controller.go
@@ -443,6 +443,7 @@ func (r *TermitePoolReconciler) reconcileStatefulSet(ctx context.Context, pool *
 									LocalObjectReference: corev1.LocalObjectReference{Name: pool.Name + "-config"},
 								}},
 							},
+							Resources: r.buildModelPullerResources(pool),
 						},
 					},
 					Containers: []corev1.Container{
@@ -450,7 +451,7 @@ func (r *TermitePoolReconciler) reconcileStatefulSet(ctx context.Context, pool *
 							Name:    "termite",
 							Image:   image,
 							Command: []string{"/termite"},
-							Args:    []string{"run", "--config", "/config/config.json"},
+							Args:    []string{"run", "--config", "/config/config.json", "--models-dir", "/models"},
 							Ports: []corev1.ContainerPort{
 								{Name: "http", ContainerPort: TermiteAPIPort, Protocol: corev1.ProtocolTCP},
 							},
@@ -470,7 +471,9 @@ func (r *TermitePoolReconciler) reconcileStatefulSet(ctx context.Context, pool *
 						{
 							Name: "models",
 							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
+								EmptyDir: &corev1.EmptyDirVolumeSource{
+									SizeLimit: quantityPtr(resource.MustParse("20Gi")),
+								},
 							},
 						},
 						{
@@ -808,6 +811,7 @@ func (r *TermitePoolReconciler) buildResources(pool *antflyaiv1alpha1.TermitePoo
 	// If user provided explicit resources, use those
 	if pool.Spec.Resources != nil {
 		resources := pool.Spec.Resources.DeepCopy()
+		ensureEphemeralStorage(resources, "10Gi")
 		// Ensure TPU resources are set if accelerator is configured
 		r.ensureTPUResources(resources, pool)
 		return *resources
@@ -824,11 +828,56 @@ func (r *TermitePoolReconciler) buildResources(pool *antflyaiv1alpha1.TermitePoo
 			corev1.ResourceCPU:    resource.MustParse("2"),
 		},
 	}
+	ensureEphemeralStorage(&resources, "10Gi")
 
 	// Add TPU resources if accelerator is configured
 	r.ensureTPUResources(&resources, pool)
 
 	return resources
+}
+
+func (r *TermitePoolReconciler) buildModelPullerResources(pool *antflyaiv1alpha1.TermitePool) corev1.ResourceRequirements {
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+		Limits: corev1.ResourceList{},
+	}
+
+	if pool.Spec.Resources != nil {
+		if req, ok := pool.Spec.Resources.Requests[corev1.ResourceEphemeralStorage]; ok {
+			resources.Requests[corev1.ResourceEphemeralStorage] = req.DeepCopy()
+		}
+		if lim, ok := pool.Spec.Resources.Limits[corev1.ResourceEphemeralStorage]; ok {
+			resources.Limits[corev1.ResourceEphemeralStorage] = lim.DeepCopy()
+		}
+	}
+
+	ensureEphemeralStorage(&resources, "10Gi")
+	return resources
+}
+
+func ensureEphemeralStorage(resources *corev1.ResourceRequirements, defaultValue string) {
+	if resources == nil {
+		return
+	}
+	if resources.Requests == nil {
+		resources.Requests = corev1.ResourceList{}
+	}
+	if resources.Limits == nil {
+		resources.Limits = corev1.ResourceList{}
+	}
+	if _, exists := resources.Requests[corev1.ResourceEphemeralStorage]; !exists {
+		resources.Requests[corev1.ResourceEphemeralStorage] = resource.MustParse(defaultValue)
+	}
+	if _, exists := resources.Limits[corev1.ResourceEphemeralStorage]; !exists {
+		resources.Limits[corev1.ResourceEphemeralStorage] = resource.MustParse(defaultValue)
+	}
+}
+
+func quantityPtr(q resource.Quantity) *resource.Quantity {
+	return &q
 }
 
 // ensureTPUResources adds google.com/tpu resource requests/limits if an accelerator is configured

--- a/pkg/operator/controllers/termitepool_controller.go
+++ b/pkg/operator/controllers/termitepool_controller.go
@@ -471,9 +471,7 @@ func (r *TermitePoolReconciler) reconcileStatefulSet(ctx context.Context, pool *
 						{
 							Name: "models",
 							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									SizeLimit: quantityPtr(resource.MustParse("20Gi")),
-								},
+								EmptyDir: r.buildModelsEmptyDir(pool),
 							},
 						},
 						{
@@ -811,7 +809,6 @@ func (r *TermitePoolReconciler) buildResources(pool *antflyaiv1alpha1.TermitePoo
 	// If user provided explicit resources, use those
 	if pool.Spec.Resources != nil {
 		resources := pool.Spec.Resources.DeepCopy()
-		ensureEphemeralStorage(resources, "10Gi")
 		// Ensure TPU resources are set if accelerator is configured
 		r.ensureTPUResources(resources, pool)
 		return *resources
@@ -828,7 +825,6 @@ func (r *TermitePoolReconciler) buildResources(pool *antflyaiv1alpha1.TermitePoo
 			corev1.ResourceCPU:    resource.MustParse("2"),
 		},
 	}
-	ensureEphemeralStorage(&resources, "10Gi")
 
 	// Add TPU resources if accelerator is configured
 	r.ensureTPUResources(&resources, pool)
@@ -836,6 +832,10 @@ func (r *TermitePoolReconciler) buildResources(pool *antflyaiv1alpha1.TermitePoo
 	return resources
 }
 
+// buildModelPullerResources gives the init container a small CPU/memory
+// footprint while mirroring any user-provided ephemeral-storage budget from
+// the main pool resources. The puller downloads into the shared /models
+// emptyDir, so it needs the same disk budget when one is specified.
 func (r *TermitePoolReconciler) buildModelPullerResources(pool *antflyaiv1alpha1.TermitePool) corev1.ResourceRequirements {
 	resources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -854,30 +854,21 @@ func (r *TermitePoolReconciler) buildModelPullerResources(pool *antflyaiv1alpha1
 		}
 	}
 
-	ensureEphemeralStorage(&resources, "10Gi")
 	return resources
 }
 
-func ensureEphemeralStorage(resources *corev1.ResourceRequirements, defaultValue string) {
-	if resources == nil {
-		return
+func (r *TermitePoolReconciler) buildModelsEmptyDir(pool *antflyaiv1alpha1.TermitePool) *corev1.EmptyDirVolumeSource {
+	emptyDir := &corev1.EmptyDirVolumeSource{}
+	if pool.Spec.Resources == nil || pool.Spec.Resources.Limits == nil {
+		return emptyDir
 	}
-	if resources.Requests == nil {
-		resources.Requests = corev1.ResourceList{}
-	}
-	if resources.Limits == nil {
-		resources.Limits = corev1.ResourceList{}
-	}
-	if _, exists := resources.Requests[corev1.ResourceEphemeralStorage]; !exists {
-		resources.Requests[corev1.ResourceEphemeralStorage] = resource.MustParse(defaultValue)
-	}
-	if _, exists := resources.Limits[corev1.ResourceEphemeralStorage]; !exists {
-		resources.Limits[corev1.ResourceEphemeralStorage] = resource.MustParse(defaultValue)
-	}
-}
 
-func quantityPtr(q resource.Quantity) *resource.Quantity {
-	return &q
+	if lim, ok := pool.Spec.Resources.Limits[corev1.ResourceEphemeralStorage]; ok {
+		limit := lim.DeepCopy()
+		emptyDir.SizeLimit = &limit
+	}
+
+	return emptyDir
 }
 
 // ensureTPUResources adds google.com/tpu resource requests/limits if an accelerator is configured

--- a/pkg/operator/controllers/termitepool_controller_test.go
+++ b/pkg/operator/controllers/termitepool_controller_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -112,6 +113,19 @@ var _ = Describe("TermitePool Controller", func() {
 			Expect(createdSts.Spec.ServiceName).To(Equal(poolName))
 			Expect(createdSts.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(createdSts.Spec.Template.Spec.Containers[0].Name).To(Equal("termite"))
+			Expect(createdSts.Spec.Template.Spec.Containers[0].Args).To(ContainElements("run", "--config", "/config/config.json", "--models-dir", "/models"))
+			Expect(createdSts.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+
+			var modelsVolume *corev1.Volume
+			for i := range createdSts.Spec.Template.Spec.Volumes {
+				if createdSts.Spec.Template.Spec.Volumes[i].Name == "models" {
+					modelsVolume = &createdSts.Spec.Template.Spec.Volumes[i]
+					break
+				}
+			}
+			Expect(modelsVolume).NotTo(BeNil())
+			Expect(modelsVolume.EmptyDir).NotTo(BeNil())
+			Expect(modelsVolume.EmptyDir.SizeLimit).To(BeNil())
 
 			// Verify TPU node selector
 			Expect(createdSts.Spec.Template.Spec.NodeSelector).To(HaveKeyWithValue(
@@ -126,6 +140,67 @@ var _ = Describe("TermitePool Controller", func() {
 			Expect(container.LivenessProbe).NotTo(BeNil())
 
 			// Cleanup
+			Expect(k8sClient.Delete(ctx, pool)).Should(Succeed())
+		})
+
+		It("Should derive model storage sizing from pool ephemeral-storage resources", func() {
+			ctx := context.Background()
+
+			pool := &antflyaiv1alpha1.TermitePool{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "storage-sized-pool",
+					Namespace: poolNamespace,
+				},
+				Spec: antflyaiv1alpha1.TermitePoolSpec{
+					WorkloadType: antflyaiv1alpha1.WorkloadTypeGeneral,
+					Models: antflyaiv1alpha1.ModelConfig{
+						Preload: []antflyaiv1alpha1.ModelSpec{
+							{Name: "bge-small-en-v1.5"},
+						},
+						LoadingStrategy: antflyaiv1alpha1.LoadingStrategyEager,
+					},
+					Replicas: antflyaiv1alpha1.ReplicaConfig{
+						Min: 1,
+						Max: 2,
+					},
+					Hardware: antflyaiv1alpha1.HardwareConfig{},
+					Resources: &corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceEphemeralStorage: resource.MustParse("7Gi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceEphemeralStorage: resource.MustParse("9Gi"),
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, pool)).Should(Succeed())
+
+			stsLookupKey := types.NamespacedName{Name: "storage-sized-pool", Namespace: poolNamespace}
+			createdSts := &appsv1.StatefulSet{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, stsLookupKey, createdSts)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(createdSts.Spec.Template.Spec.InitContainers).To(HaveLen(1))
+			puller := createdSts.Spec.Template.Spec.InitContainers[0]
+			Expect(puller.Resources.Requests).To(HaveKeyWithValue(corev1.ResourceEphemeralStorage, resource.MustParse("7Gi")))
+			Expect(puller.Resources.Limits).To(HaveKeyWithValue(corev1.ResourceEphemeralStorage, resource.MustParse("9Gi")))
+
+			var modelsVolume *corev1.Volume
+			for i := range createdSts.Spec.Template.Spec.Volumes {
+				if createdSts.Spec.Template.Spec.Volumes[i].Name == "models" {
+					modelsVolume = &createdSts.Spec.Template.Spec.Volumes[i]
+					break
+				}
+			}
+			Expect(modelsVolume).NotTo(BeNil())
+			Expect(modelsVolume.EmptyDir).NotTo(BeNil())
+			Expect(modelsVolume.EmptyDir.SizeLimit).NotTo(BeNil())
+			Expect(modelsVolume.EmptyDir.SizeLimit.String()).To(Equal("9Gi"))
+
 			Expect(k8sClient.Delete(ctx, pool)).Should(Succeed())
 		})
 	})

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -18,6 +18,7 @@ package proxy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -624,6 +625,8 @@ type Proxy struct {
 
 	defaultPool string
 	listenAddr  string
+
+	backgroundOnce sync.Once
 }
 
 // Config holds proxy configuration
@@ -671,33 +674,79 @@ func NewProxy(cfg Config) *Proxy {
 	return p
 }
 
-// Start starts the proxy server
-func (p *Proxy) Start(ctx context.Context) error {
-	// Main API mux
+// ResolutionError represents a request resolution failure that maps directly to
+// an HTTP response status.
+type ResolutionError struct {
+	StatusCode int
+	Message    string
+	RetryAfter int
+}
+
+func (e *ResolutionError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return http.StatusText(e.StatusCode)
+}
+
+// ResolveRequest contains the routing inputs needed to select an upstream
+// Termite endpoint. This is exported so external services (for example Colony)
+// can reuse the proxy's model/pool/route resolution without reimplementing it.
+type ResolveRequest struct {
+	Operation OperationType
+	Model     string
+	Headers   map[string]string
+	Timestamp time.Time
+}
+
+// ResolvedRequest is the result of routing a request to a concrete endpoint.
+type ResolvedRequest struct {
+	Pool         string
+	WorkloadType WorkloadType
+	Endpoint     *Endpoint
+	MatchedRoute *Route
+}
+
+// Handler returns the proxy's public HTTP handler without starting an HTTP
+// server. This makes the package easier to embed in another service.
+func (p *Proxy) Handler() http.Handler {
 	apiMux := http.NewServeMux()
 	apiMux.HandleFunc("/api/embed", p.handleEmbed)
 	apiMux.HandleFunc("/api/chunk", p.handleChunk)
 	apiMux.HandleFunc("/api/rerank", p.handleRerank)
+	apiMux.HandleFunc("/api/recognize", p.handleRecognize)
+	apiMux.HandleFunc("/api/extract", p.handleExtract)
 	apiMux.HandleFunc("/healthz", p.handleHealth)
 	apiMux.HandleFunc("/readyz", p.handleReady)
+	return apiMux
+}
 
+// StartBackground starts the registry refresh loop and optional RouteWatcher
+// without binding an HTTP listener. Embedding services should call this once.
+func (p *Proxy) StartBackground(ctx context.Context) {
+	p.backgroundOnce.Do(func() {
+		if p.registry.refreshInterval > 0 {
+			go p.refreshLoop(ctx)
+		}
+		if p.routeWatcher != nil {
+			go func() {
+				if err := p.routeWatcher.Start(ctx); err != nil {
+					p.logger.Error("RouteWatcher stopped", zap.Error(err))
+				}
+			}()
+		}
+	})
+}
+
+// Start starts the proxy server
+func (p *Proxy) Start(ctx context.Context) error {
 	p.server = &http.Server{
 		Addr:              p.listenAddr,
-		Handler:           apiMux,
+		Handler:           p.Handler(),
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
-	// Start background refresh
-	go p.refreshLoop(ctx)
-
-	// Start RouteWatcher if configured
-	if p.routeWatcher != nil {
-		go func() {
-			if err := p.routeWatcher.Start(ctx); err != nil {
-				p.logger.Error("RouteWatcher stopped", zap.Error(err))
-			}
-		}()
-	}
+	p.StartBackground(ctx)
 
 	return p.server.ListenAndServe()
 }
@@ -720,6 +769,98 @@ func (p *Proxy) handleChunk(w http.ResponseWriter, r *http.Request) {
 // handleRerank routes reranking requests
 func (p *Proxy) handleRerank(w http.ResponseWriter, r *http.Request) {
 	p.proxyRequest(w, r, "rerank")
+}
+
+// handleRecognize routes NER/recognition requests.
+func (p *Proxy) handleRecognize(w http.ResponseWriter, r *http.Request) {
+	p.proxyRequest(w, r, "recognize")
+}
+
+// handleExtract routes schema-based extraction requests.
+func (p *Proxy) handleExtract(w http.ResponseWriter, r *http.Request) {
+	p.proxyRequest(w, r, "extract")
+}
+
+// ResolveRequest resolves an operation/model/header tuple to a concrete
+// endpoint. This is the main library seam for embedding the Termite proxy logic
+// in another service without depending on the proxy's own HTTP server.
+func (p *Proxy) ResolveRequest(ctx context.Context, req ResolveRequest) (*ResolvedRequest, error) {
+	requestTime := req.Timestamp
+	if requestTime.IsZero() {
+		requestTime = time.Now()
+	}
+
+	headers := req.Headers
+	if headers == nil {
+		headers = map[string]string{}
+	}
+
+	routeReq := &RouteRequest{
+		Operation: req.Operation,
+		Model:     req.Model,
+		Headers:   headers,
+		Timestamp: requestTime,
+	}
+
+	var pool string
+	var matchedRoute *Route
+	if route := p.router.RouteManager().Match(routeReq); route != nil {
+		matchedRoute = route
+		if route.RateLimiter != nil && !route.RateLimiter.Allow(req.Model) {
+			return nil, &ResolutionError{
+				StatusCode: http.StatusTooManyRequests,
+				Message:    "rate limit exceeded",
+			}
+		}
+
+		dest, err := p.router.RouteManager().SelectDestination(route, routeReq, p.registry)
+		if err == nil && dest != nil {
+			pool = dest.Pool
+		} else if route.Fallback != nil {
+			switch route.Fallback.Action {
+			case "reject":
+				statusCode := route.Fallback.StatusCode
+				if statusCode == 0 {
+					statusCode = http.StatusServiceUnavailable
+				}
+				msg := route.Fallback.Message
+				if msg == "" {
+					msg = "no healthy endpoints available"
+				}
+				return nil, &ResolutionError{
+					StatusCode: statusCode,
+					Message:    msg,
+					RetryAfter: route.Fallback.RetryAfter,
+				}
+			case "redirect":
+				pool = route.Fallback.RedirectPool
+			}
+		}
+	}
+
+	if pool == "" {
+		pool = headers["X-Termite-Pool"]
+	}
+	if pool == "" {
+		pool = p.defaultPool
+	}
+
+	workloadType := workloadTypeForRequest(req.Operation, headers["X-Termite-Workload-Type"])
+
+	endpoint, err := p.router.RouteRequest(ctx, req.Model, pool, workloadType)
+	if err != nil {
+		return nil, &ResolutionError{
+			StatusCode: http.StatusServiceUnavailable,
+			Message:    err.Error(),
+		}
+	}
+
+	return &ResolvedRequest{
+		Pool:         pool,
+		WorkloadType: workloadType,
+		Endpoint:     endpoint,
+		MatchedRoute: matchedRoute,
+	}, nil
 }
 
 func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request, operation string) {
@@ -746,77 +887,31 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request, operation s
 		headers[k] = r.Header.Get(k)
 	}
 
-	// Try route-based matching first
-	var pool string
-	routeReq := &RouteRequest{
+	resolved, err := p.ResolveRequest(r.Context(), ResolveRequest{
 		Operation: OperationType(operation),
 		Model:     req.Model,
 		Headers:   headers,
 		Timestamp: start,
-	}
-
-	if matchedRoute := p.router.RouteManager().Match(routeReq); matchedRoute != nil {
-		// Check rate limiting
-		if matchedRoute.RateLimiter != nil && !matchedRoute.RateLimiter.Allow(req.Model) {
-			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
+	})
+	if err != nil {
+		var resolutionErr *ResolutionError
+		if errors.As(err, &resolutionErr) {
+			if resolutionErr.RetryAfter > 0 {
+				w.Header().Set("Retry-After", fmt.Sprintf("%d", resolutionErr.RetryAfter))
+			}
+			statusLabel := "error"
+			if resolutionErr.StatusCode == http.StatusServiceUnavailable {
+				statusLabel = "no_endpoint"
+			}
+			requestsTotal.WithLabelValues(p.defaultPool, req.Model, operation, statusLabel).Inc()
+			http.Error(w, resolutionErr.Message, resolutionErr.StatusCode)
 			return
 		}
-
-		// Select destination from matched route
-		dest, err := p.router.RouteManager().SelectDestination(matchedRoute, routeReq, p.registry)
-		if err == nil && dest != nil {
-			pool = dest.Pool
-		} else if matchedRoute.Fallback != nil {
-			// Handle fallback
-			switch matchedRoute.Fallback.Action {
-			case "reject":
-				statusCode := matchedRoute.Fallback.StatusCode
-				if statusCode == 0 {
-					statusCode = 503
-				}
-				msg := matchedRoute.Fallback.Message
-				if msg == "" {
-					msg = "no healthy endpoints available"
-				}
-				if matchedRoute.Fallback.RetryAfter > 0 {
-					w.Header().Set("Retry-After", fmt.Sprintf("%d", matchedRoute.Fallback.RetryAfter))
-				}
-				http.Error(w, msg, statusCode)
-				return
-			case "redirect":
-				pool = matchedRoute.Fallback.RedirectPool
-			}
-		}
-	}
-
-	// Fall back to X-Termite-Pool header or default pool
-	if pool == "" {
-		pool = r.Header.Get("X-Termite-Pool")
-	}
-	if pool == "" {
-		pool = p.defaultPool
-	}
-
-	// Determine workload type from header or infer from operation
-	workloadType := WorkloadType(r.Header.Get("X-Termite-Workload-Type"))
-	if workloadType == "" {
-		switch operation {
-		case "embed", "rerank":
-			workloadType = WorkloadTypeReadHeavy
-		case "chunk":
-			workloadType = WorkloadTypeWriteHeavy
-		default:
-			workloadType = WorkloadTypeGeneral
-		}
-	}
-
-	// Route the request
-	endpoint, err := p.router.RouteRequest(r.Context(), req.Model, pool, workloadType)
-	if err != nil {
-		requestsTotal.WithLabelValues(pool, req.Model, operation, "no_endpoint").Inc()
+		requestsTotal.WithLabelValues(p.defaultPool, req.Model, operation, "no_endpoint").Inc()
 		http.Error(w, err.Error(), http.StatusServiceUnavailable)
 		return
 	}
+	endpoint := resolved.Endpoint
 
 	// Track active connections
 	atomic.AddInt32(&endpoint.Connections, 1)
@@ -855,6 +950,21 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request, operation s
 	}
 
 	proxy.ServeHTTP(w, r) //nolint:gosec // G704: endpoint address is from trusted internal registry
+}
+
+func workloadTypeForRequest(operation OperationType, headerValue string) WorkloadType {
+	if headerValue != "" {
+		return WorkloadType(headerValue)
+	}
+
+	switch operation {
+	case "embed", "rerank", "recognize", "extract":
+		return WorkloadTypeReadHeavy
+	case "chunk":
+		return WorkloadTypeWriteHeavy
+	default:
+		return WorkloadTypeGeneral
+	}
 }
 
 type bodyReader struct {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -680,6 +680,7 @@ type ResolutionError struct {
 	StatusCode int
 	Message    string
 	RetryAfter int
+	Pool       string
 }
 
 func (e *ResolutionError) Error() string {
@@ -794,6 +795,7 @@ func (p *Proxy) ResolveRequest(ctx context.Context, req ResolveRequest) (*Resolv
 	if headers == nil {
 		headers = map[string]string{}
 	}
+	requestedPool := requestedPoolFromHeaders(headers, p.defaultPool)
 
 	routeReq := &RouteRequest{
 		Operation: req.Operation,
@@ -802,14 +804,16 @@ func (p *Proxy) ResolveRequest(ctx context.Context, req ResolveRequest) (*Resolv
 		Timestamp: requestTime,
 	}
 
-	var pool string
+	pool := requestedPool
 	var matchedRoute *Route
 	if route := p.router.RouteManager().Match(routeReq); route != nil {
 		matchedRoute = route
+		routePool := inferRoutePool(route, requestedPool)
 		if route.RateLimiter != nil && !route.RateLimiter.Allow(req.Model) {
 			return nil, &ResolutionError{
 				StatusCode: http.StatusTooManyRequests,
 				Message:    "rate limit exceeded",
+				Pool:       routePool,
 			}
 		}
 
@@ -831,18 +835,12 @@ func (p *Proxy) ResolveRequest(ctx context.Context, req ResolveRequest) (*Resolv
 					StatusCode: statusCode,
 					Message:    msg,
 					RetryAfter: route.Fallback.RetryAfter,
+					Pool:       routePool,
 				}
 			case "redirect":
 				pool = route.Fallback.RedirectPool
 			}
 		}
-	}
-
-	if pool == "" {
-		pool = headers["X-Termite-Pool"]
-	}
-	if pool == "" {
-		pool = p.defaultPool
 	}
 
 	workloadType := workloadTypeForRequest(req.Operation, headers["X-Termite-Workload-Type"])
@@ -852,6 +850,7 @@ func (p *Proxy) ResolveRequest(ctx context.Context, req ResolveRequest) (*Resolv
 		return nil, &ResolutionError{
 			StatusCode: http.StatusServiceUnavailable,
 			Message:    err.Error(),
+			Pool:       pool,
 		}
 	}
 
@@ -903,7 +902,7 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request, operation s
 			if resolutionErr.StatusCode == http.StatusServiceUnavailable {
 				statusLabel = "no_endpoint"
 			}
-			requestsTotal.WithLabelValues(p.defaultPool, req.Model, operation, statusLabel).Inc()
+			requestsTotal.WithLabelValues(metricPoolLabel(resolutionErr.Pool, p.defaultPool), req.Model, operation, statusLabel).Inc()
 			http.Error(w, resolutionErr.Message, resolutionErr.StatusCode)
 			return
 		}
@@ -965,6 +964,47 @@ func workloadTypeForRequest(operation OperationType, headerValue string) Workloa
 	default:
 		return WorkloadTypeGeneral
 	}
+}
+
+func requestedPoolFromHeaders(headers map[string]string, defaultPool string) string {
+	if pool := headers["X-Termite-Pool"]; pool != "" {
+		return pool
+	}
+	return defaultPool
+}
+
+func inferRoutePool(route *Route, requestedPool string) string {
+	if route == nil {
+		return requestedPool
+	}
+	if route.Fallback != nil && route.Fallback.Action == "redirect" && route.Fallback.RedirectPool != "" {
+		return route.Fallback.RedirectPool
+	}
+
+	var pool string
+	for _, dest := range route.Destinations {
+		if dest.Pool == "" {
+			continue
+		}
+		if pool == "" {
+			pool = dest.Pool
+			continue
+		}
+		if pool != dest.Pool {
+			return requestedPool
+		}
+	}
+	if pool != "" {
+		return pool
+	}
+	return requestedPool
+}
+
+func metricPoolLabel(pool, defaultPool string) string {
+	if pool != "" {
+		return pool
+	}
+	return defaultPool
 }
 
 type bodyReader struct {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -1,0 +1,64 @@
+package proxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestResolveRequestNoEndpointUsesRequestedPool(t *testing.T) {
+	p := NewProxy(Config{DefaultPool: "default-pool"})
+
+	_, err := p.ResolveRequest(context.Background(), ResolveRequest{
+		Operation: OperationType("embed"),
+		Model:     "bge-small-en-v1.5",
+		Headers: map[string]string{
+			"X-Termite-Pool": "requested-pool",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected resolution error")
+	}
+
+	var resolutionErr *ResolutionError
+	if !errors.As(err, &resolutionErr) {
+		t.Fatalf("expected ResolutionError, got %T", err)
+	}
+	if resolutionErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected status %d, got %d", http.StatusServiceUnavailable, resolutionErr.StatusCode)
+	}
+	if resolutionErr.Pool != "requested-pool" {
+		t.Fatalf("expected pool %q, got %q", "requested-pool", resolutionErr.Pool)
+	}
+}
+
+func TestResolveRequestRateLimitUsesSingleRoutePool(t *testing.T) {
+	p := NewProxy(Config{DefaultPool: "default-pool"})
+	p.Router().RouteManager().AddRoute(&Route{
+		Name: "rate-limited-route",
+		Destinations: []Destination{
+			{Pool: "routed-pool", Weight: 1},
+		},
+		RateLimiter: NewRateLimiter(0, 0, false),
+	})
+
+	_, err := p.ResolveRequest(context.Background(), ResolveRequest{
+		Operation: OperationType("embed"),
+		Model:     "bge-small-en-v1.5",
+	})
+	if err == nil {
+		t.Fatal("expected resolution error")
+	}
+
+	var resolutionErr *ResolutionError
+	if !errors.As(err, &resolutionErr) {
+		t.Fatalf("expected ResolutionError, got %T", err)
+	}
+	if resolutionErr.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("expected status %d, got %d", http.StatusTooManyRequests, resolutionErr.StatusCode)
+	}
+	if resolutionErr.Pool != "routed-pool" {
+		t.Fatalf("expected pool %q, got %q", "routed-pool", resolutionErr.Pool)
+	}
+}


### PR DESCRIPTION
## Summary

This PR makes two generic improvements to Termite:

1. Expose reusable proxy library seams
2. Fix model-directory and local-storage behavior for operator-managed pools

## What this changes

### Proxy library seams

pkg/proxy is easier to embed from another Go service.

This adds reusable seams for:

- serving the proxy HTTP handler without forcing the package to own the whole server
- starting proxy background lifecycle separately from HTTP binding
- resolving requests to pools/endpoints through the proxy’s existing routing logic
- routing additional Termite operations such as recognize and extract

Concretely, this adds:

- Handler()
- StartBackground(context.Context)
- ResolveRequest(...)
- exported resolution types for callers that want to reuse routing decisions

### Operator-managed pool correctness

The Termite operator already downloads models into /models, but the runtime container was not explicitly
started with that models directory.

This PR updates operator-managed pools to:

- start Termite with --models-dir /models
- give the model-puller explicit ephemeral-storage resources
- set local storage defaults for the shared models volume

Without the models-dir fix, model downloads can succeed while the runtime still looks in the default local
models path.

## Why this is useful

- lets other Go services reuse Termite’s routing logic instead of reimplementing pool/route resolution
- makes proxy lifecycle management more flexible for embedding
- fixes a real correctness issue for operator-managed pools
- makes operator-managed model storage behavior more explicit

## Testing

Validated with:

- go test ./... in pkg/proxy
- go test ./... in pkg/operator

Also reviewed against the operator/runtime flow:

- init container pulls models into /models
- runtime now reads from the same /models root

## Notes

There are two follow-up issues I’d still want to address before merge or immediately after:

- local model storage defaults are currently a bit too rigid
- some proxy error metrics are attributed to defaultPool rather than the intended/requested pool