### PR TITLE
Add WithAPIKey option for authenticated Termite deployments

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -22,6 +22,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -100,48 +101,27 @@ type TermiteClient struct {
 	baseURL string
 }
 
-// Option configures a TermiteClient.
-type Option func(*clientConfig)
-
-// clientConfig holds configuration applied via Option values.
-type clientConfig struct {
-	apiKey string
-}
-
-// WithAPIKey configures the client to send "Authorization: Bearer <key>" on
-// every request. Use this when targeting an authenticated deployment such as
-// the Colony-hosted termite edge.
-func WithAPIKey(key string) Option {
-	return func(c *clientConfig) {
-		c.apiKey = key
-	}
-}
-
 // NewTermiteClient creates a new Termite client.
 // The baseURL should be the server address (e.g., "http://localhost:8080").
 // The /api prefix is automatically appended.
-func NewTermiteClient(baseURL string, httpClient *http.Client, opts ...Option) (*TermiteClient, error) {
+//
+// Pass authentication by wrapping one of WithBasicAuth, WithApiKey, or
+// WithBearerToken in oapi.WithRequestEditorFn and supplying it as an option,
+// matching the pattern used by the Antfly Go client:
+//
+//	c, err := client.NewTermiteClient(baseURL, nil,
+//	    oapi.WithRequestEditorFn(client.WithBearerToken(token)))
+func NewTermiteClient(baseURL string, httpClient *http.Client, opts ...oapi.ClientOption) (*TermiteClient, error) {
 	// Append /api prefix for the Termite API
 	apiURL := strings.TrimSuffix(baseURL, "/") + "/api"
 
-	cfg := &clientConfig{}
-	for _, opt := range opts {
-		opt(cfg)
-	}
-
-	var oapiOpts []oapi.ClientOption
+	allOpts := make([]oapi.ClientOption, 0, len(opts)+1)
 	if httpClient != nil {
-		oapiOpts = append(oapiOpts, oapi.WithHTTPClient(httpClient))
+		allOpts = append(allOpts, oapi.WithHTTPClient(httpClient))
 	}
-	if cfg.apiKey != "" {
-		apiKey := cfg.apiKey
-		oapiOpts = append(oapiOpts, oapi.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
-			req.Header.Set("Authorization", "Bearer "+apiKey)
-			return nil
-		}))
-	}
+	allOpts = append(allOpts, opts...)
 
-	client, err := oapi.NewClientWithResponses(apiURL, oapiOpts...)
+	client, err := oapi.NewClientWithResponses(apiURL, allOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -149,6 +129,35 @@ func NewTermiteClient(baseURL string, httpClient *http.Client, opts ...Option) (
 		client:  client,
 		baseURL: apiURL,
 	}, nil
+}
+
+// WithBasicAuth returns a RequestEditorFn that adds HTTP Basic Authentication.
+func WithBasicAuth(username, password string) oapi.RequestEditorFn {
+	encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+	return func(_ context.Context, req *http.Request) error {
+		req.Header.Set("Authorization", "Basic "+encoded)
+		return nil
+	}
+}
+
+// WithApiKey returns a RequestEditorFn that adds API Key authentication.
+// The credential is sent as: Authorization: ApiKey base64(keyID:keySecret)
+func WithApiKey(keyID, keySecret string) oapi.RequestEditorFn {
+	encoded := base64.StdEncoding.EncodeToString([]byte(keyID + ":" + keySecret))
+	return func(_ context.Context, req *http.Request) error {
+		req.Header.Set("Authorization", "ApiKey "+encoded)
+		return nil
+	}
+}
+
+// WithBearerToken returns a RequestEditorFn that adds Bearer token authentication.
+// The token should be base64(keyID:keySecret) for Antfly API keys, or an opaque
+// token from a proxy (e.g., Colony's termite edge).
+func WithBearerToken(token string) oapi.RequestEditorFn {
+	return func(_ context.Context, req *http.Request) error {
+		req.Header.Set("Authorization", "Bearer "+token)
+		return nil
+	}
 }
 
 // Client returns the underlying oapi-codegen client for direct API access.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -100,19 +100,48 @@ type TermiteClient struct {
 	baseURL string
 }
 
+// Option configures a TermiteClient.
+type Option func(*clientConfig)
+
+// clientConfig holds configuration applied via Option values.
+type clientConfig struct {
+	apiKey string
+}
+
+// WithAPIKey configures the client to send "Authorization: Bearer <key>" on
+// every request. Use this when targeting an authenticated deployment such as
+// the Colony-hosted termite edge.
+func WithAPIKey(key string) Option {
+	return func(c *clientConfig) {
+		c.apiKey = key
+	}
+}
+
 // NewTermiteClient creates a new Termite client.
 // The baseURL should be the server address (e.g., "http://localhost:8080").
 // The /api prefix is automatically appended.
-func NewTermiteClient(baseURL string, httpClient *http.Client) (*TermiteClient, error) {
+func NewTermiteClient(baseURL string, httpClient *http.Client, opts ...Option) (*TermiteClient, error) {
 	// Append /api prefix for the Termite API
 	apiURL := strings.TrimSuffix(baseURL, "/") + "/api"
 
-	var opts []oapi.ClientOption
-	if httpClient != nil {
-		opts = append(opts, oapi.WithHTTPClient(httpClient))
+	cfg := &clientConfig{}
+	for _, opt := range opts {
+		opt(cfg)
 	}
 
-	client, err := oapi.NewClientWithResponses(apiURL, opts...)
+	var oapiOpts []oapi.ClientOption
+	if httpClient != nil {
+		oapiOpts = append(oapiOpts, oapi.WithHTTPClient(httpClient))
+	}
+	if cfg.apiKey != "" {
+		apiKey := cfg.apiKey
+		oapiOpts = append(oapiOpts, oapi.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+			return nil
+		}))
+	}
+
+	client, err := oapi.NewClientWithResponses(apiURL, oapiOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -16,6 +16,7 @@ package client
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"io"
@@ -26,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/antflydb/termite/pkg/client/oapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -621,10 +623,14 @@ func TestClient_ServerErr(t *testing.T) {
 	assert.Contains(t, err.Error(), "server error")
 }
 
-func TestWithAPIKey_InjectsAuthHeader(t *testing.T) {
-	var gotHeader string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotHeader = r.Header.Get("Authorization")
+// modelsListHandler returns an HTTP handler that emits a minimal but valid
+// /api/models response. Used by the auth-header tests which only care about
+// request headers, not response content.
+func modelsListHandler(onRequest func(r *http.Request)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if onRequest != nil {
+			onRequest(r)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"embedders":    map[string]any{},
@@ -638,10 +644,18 @@ func TestWithAPIKey_InjectsAuthHeader(t *testing.T) {
 			"readers":      map[string]any{},
 			"transcribers": map[string]any{},
 		})
+	}
+}
+
+func TestWithBearerToken_InjectsAuthHeader(t *testing.T) {
+	var gotHeader string
+	server := httptest.NewServer(modelsListHandler(func(r *http.Request) {
+		gotHeader = r.Header.Get("Authorization")
 	}))
 	defer server.Close()
 
-	termiteClient, err := NewTermiteClient(server.URL, nil, WithAPIKey("searchaf_abc_def"))
+	termiteClient, err := NewTermiteClient(server.URL, nil,
+		oapi.WithRequestEditorFn(WithBearerToken("searchaf_abc_def")))
 	require.NoError(t, err)
 
 	_, err = termiteClient.ListModels(context.Background())
@@ -649,23 +663,44 @@ func TestWithAPIKey_InjectsAuthHeader(t *testing.T) {
 	assert.Equal(t, "Bearer searchaf_abc_def", gotHeader)
 }
 
-func TestWithoutAPIKey_NoAuthHeader(t *testing.T) {
+func TestWithApiKey_InjectsBase64Credentials(t *testing.T) {
 	var gotHeader string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(modelsListHandler(func(r *http.Request) {
 		gotHeader = r.Header.Get("Authorization")
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"embedders":    map[string]any{},
-			"chunkers":     map[string]any{},
-			"rerankers":    map[string]any{},
-			"generators":   map[string]any{},
-			"recognizers":  map[string]any{},
-			"extractors":   map[string]any{},
-			"rewriters":    map[string]any{},
-			"classifiers":  map[string]any{},
-			"readers":      map[string]any{},
-			"transcribers": map[string]any{},
-		})
+	}))
+	defer server.Close()
+
+	termiteClient, err := NewTermiteClient(server.URL, nil,
+		oapi.WithRequestEditorFn(WithApiKey("key-id", "key-secret")))
+	require.NoError(t, err)
+
+	_, err = termiteClient.ListModels(context.Background())
+	require.NoError(t, err)
+	expected := "ApiKey " + base64.StdEncoding.EncodeToString([]byte("key-id:key-secret"))
+	assert.Equal(t, expected, gotHeader)
+}
+
+func TestWithBasicAuth_InjectsBase64Credentials(t *testing.T) {
+	var gotHeader string
+	server := httptest.NewServer(modelsListHandler(func(r *http.Request) {
+		gotHeader = r.Header.Get("Authorization")
+	}))
+	defer server.Close()
+
+	termiteClient, err := NewTermiteClient(server.URL, nil,
+		oapi.WithRequestEditorFn(WithBasicAuth("user", "pass")))
+	require.NoError(t, err)
+
+	_, err = termiteClient.ListModels(context.Background())
+	require.NoError(t, err)
+	expected := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	assert.Equal(t, expected, gotHeader)
+}
+
+func TestWithoutAuth_NoAuthHeader(t *testing.T) {
+	var gotHeader string
+	server := httptest.NewServer(modelsListHandler(func(r *http.Request) {
+		gotHeader = r.Header.Get("Authorization")
 	}))
 	defer server.Close()
 
@@ -677,28 +712,16 @@ func TestWithoutAPIKey_NoAuthHeader(t *testing.T) {
 	assert.Empty(t, gotHeader)
 }
 
-func TestWithAPIKey_PersistsAcrossRequests(t *testing.T) {
+func TestAuthHeader_PersistsAcrossRequests(t *testing.T) {
 	callCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(modelsListHandler(func(r *http.Request) {
 		assert.Equal(t, "Bearer searchaf_abc_def", r.Header.Get("Authorization"))
 		callCount++
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"embedders":    map[string]any{},
-			"chunkers":     map[string]any{},
-			"rerankers":    map[string]any{},
-			"generators":   map[string]any{},
-			"recognizers":  map[string]any{},
-			"extractors":   map[string]any{},
-			"rewriters":    map[string]any{},
-			"classifiers":  map[string]any{},
-			"readers":      map[string]any{},
-			"transcribers": map[string]any{},
-		})
 	}))
 	defer server.Close()
 
-	termiteClient, err := NewTermiteClient(server.URL, nil, WithAPIKey("searchaf_abc_def"))
+	termiteClient, err := NewTermiteClient(server.URL, nil,
+		oapi.WithRequestEditorFn(WithBearerToken("searchaf_abc_def")))
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -709,7 +732,7 @@ func TestWithAPIKey_PersistsAcrossRequests(t *testing.T) {
 	assert.Equal(t, 2, callCount)
 }
 
-func TestWithAPIKey_PreservesOtherHeaders(t *testing.T) {
+func TestAuthHeader_PreservesOtherHeaders(t *testing.T) {
 	// EmbedJSON sets Accept: application/json via its own RequestEditorFn.
 	// Verify that the auth header and the Accept header coexist.
 	expectedEmbeddings := [][]float32{{0.1, 0.2, 0.3}}
@@ -725,7 +748,8 @@ func TestWithAPIKey_PreservesOtherHeaders(t *testing.T) {
 	}))
 	defer server.Close()
 
-	termiteClient, err := NewTermiteClient(server.URL, nil, WithAPIKey("searchaf_abc_def"))
+	termiteClient, err := NewTermiteClient(server.URL, nil,
+		oapi.WithRequestEditorFn(WithBearerToken("searchaf_abc_def")))
 	require.NoError(t, err)
 
 	resp, err := termiteClient.EmbedJSON(context.Background(), "test-model", []string{"hello"})

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -621,6 +621,119 @@ func TestClient_ServerErr(t *testing.T) {
 	assert.Contains(t, err.Error(), "server error")
 }
 
+func TestWithAPIKey_InjectsAuthHeader(t *testing.T) {
+	var gotHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"embedders":    map[string]any{},
+			"chunkers":     map[string]any{},
+			"rerankers":    map[string]any{},
+			"generators":   map[string]any{},
+			"recognizers":  map[string]any{},
+			"extractors":   map[string]any{},
+			"rewriters":    map[string]any{},
+			"classifiers":  map[string]any{},
+			"readers":      map[string]any{},
+			"transcribers": map[string]any{},
+		})
+	}))
+	defer server.Close()
+
+	termiteClient, err := NewTermiteClient(server.URL, nil, WithAPIKey("searchaf_abc_def"))
+	require.NoError(t, err)
+
+	_, err = termiteClient.ListModels(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer searchaf_abc_def", gotHeader)
+}
+
+func TestWithoutAPIKey_NoAuthHeader(t *testing.T) {
+	var gotHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"embedders":    map[string]any{},
+			"chunkers":     map[string]any{},
+			"rerankers":    map[string]any{},
+			"generators":   map[string]any{},
+			"recognizers":  map[string]any{},
+			"extractors":   map[string]any{},
+			"rewriters":    map[string]any{},
+			"classifiers":  map[string]any{},
+			"readers":      map[string]any{},
+			"transcribers": map[string]any{},
+		})
+	}))
+	defer server.Close()
+
+	termiteClient, err := NewTermiteClient(server.URL, nil)
+	require.NoError(t, err)
+
+	_, err = termiteClient.ListModels(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, gotHeader)
+}
+
+func TestWithAPIKey_PersistsAcrossRequests(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer searchaf_abc_def", r.Header.Get("Authorization"))
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"embedders":    map[string]any{},
+			"chunkers":     map[string]any{},
+			"rerankers":    map[string]any{},
+			"generators":   map[string]any{},
+			"recognizers":  map[string]any{},
+			"extractors":   map[string]any{},
+			"rewriters":    map[string]any{},
+			"classifiers":  map[string]any{},
+			"readers":      map[string]any{},
+			"transcribers": map[string]any{},
+		})
+	}))
+	defer server.Close()
+
+	termiteClient, err := NewTermiteClient(server.URL, nil, WithAPIKey("searchaf_abc_def"))
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = termiteClient.ListModels(ctx)
+	require.NoError(t, err)
+	_, err = termiteClient.ListModels(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestWithAPIKey_PreservesOtherHeaders(t *testing.T) {
+	// EmbedJSON sets Accept: application/json via its own RequestEditorFn.
+	// Verify that the auth header and the Accept header coexist.
+	expectedEmbeddings := [][]float32{{0.1, 0.2, 0.3}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer searchaf_abc_def", r.Header.Get("Authorization"))
+		assert.Contains(t, r.Header.Get("Accept"), "application/json")
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"model":      "test-model",
+			"embeddings": expectedEmbeddings,
+		})
+	}))
+	defer server.Close()
+
+	termiteClient, err := NewTermiteClient(server.URL, nil, WithAPIKey("searchaf_abc_def"))
+	require.NoError(t, err)
+
+	resp, err := termiteClient.EmbedJSON(context.Background(), "test-model", []string{"hello"})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Len(t, resp.Embeddings, 1)
+}
+
 func TestClient_URLNormalization(t *testing.T) {
 	// Test that trailing slash is handled correctly
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
NewTermiteClient now accepts optional Option values. WithAPIKey("...") configures the client to send "Authorization: Bearer <key>" on every request.

This should preserve backwards compatibility with the '...' signature so the existing two-argument callers still work. @ajroetker curious if you think the Option arg solution is the right one vs explicit optional apiKey.